### PR TITLE
Fixed incompatible gradle plugin error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.0' apply false
-    id 'com.android.library' version '7.4.0' apply false
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
 }


### PR DESCRIPTION
Bei einem PR haben wir versehentlich das gradle plugin auf eine mit unsere Anwendung nicht kompatiblen Version geändert.
![image](https://user-images.githubusercontent.com/110382387/213923632-05fbc401-8fcf-4096-a92f-156d131c517c.png)
