### PR TITLE
Add build.gradle to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 /.gradle/7.4/fileHashes/fileHashes.bin
 /.gradle/buildOutputCleanup/outputFiles.bin
 /.gradle/7.4/fileHashes/resourceHashesCache.bin
+build.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,0 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-plugins {
-    id 'com.android.application' version '7.4.0' apply false
-    id 'com.android.library' version '7.4.0' apply false
-}


### PR DESCRIPTION
Das build.gradle sollte im repo gelöscht und ins gitignore gepackt werden, da sich die Gradle Version je nach unserer Version von Android Studio ändern kann.